### PR TITLE
Support to read .gitignore

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -45,8 +45,7 @@ jobs:
 
       - name: Create dirs which cannot add due to git-ignore features
         run: |
-            mkdir testdata/service-f
-            touch testdata/service-f/ignorez
+            mkdir -p testdata/service-f/ignorez
 
       - name: Test with the Go CLI
         shell: 'script -q -e -c "bash {0}"'
@@ -80,8 +79,7 @@ jobs:
 
       - name: Create dirs which cannot add due to git-ignore features
         run: |
-            mkdir testdata/service-f
-            touch testdata/service-f/ignorez
+            mkdir -p testdata/service-f/ignorez
 
       - name: Test with the Go CLI
         run: go test ./... -race -shuffle=on -timeout=3m -cover -v

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -43,6 +43,11 @@ jobs:
           mkdir -p $HOME/.config/irir
           curl -L https://bit.ly/irir-gotest-conf > $HOME/.config/irir/irir_rule.yaml
 
+      - name: Create dirs which cannot add due to git-ignore features
+        run: |
+            mkdir testdata/service-f
+            touch testdata/service-f/ignorez
+
       - name: Test with the Go CLI
         shell: 'script -q -e -c "bash {0}"'
         run: irir gotest -- go test -v -shuffle=on -timeout=3m -cover ./...
@@ -72,6 +77,11 @@ jobs:
 
       - name: Build
         run: go build -v ./...
+
+      - name: Create dirs which cannot add due to git-ignore features
+        run: |
+            mkdir testdata/service-f
+            touch testdata/service-f/ignorez
 
       - name: Test with the Go CLI
         run: go test ./... -race -shuffle=on -timeout=3m -cover -v

--- a/README.md
+++ b/README.md
@@ -65,8 +65,11 @@ service-b/main.go
 ## Notes
 
 * Not follow symbolic links
-* Files and directories whose names start with a dot are ignored
-* Support .gitignore file to ignore files and directories
+* Files and directories whose names start with a dot are ignored by default
+    * Use `--hidden` option to search for hidden-files/directories
+        * Still ignore `.git` and `.gitkeep`
+* Support .gitignore file to ignore files and directories by default
+    * Use `--skip-gitignore` option to enable `.gitignore` file
 
 Also See `--help` for more options.
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ service-b/main.go
 
 * Not follow symbolic links
 * Files and directories whose names start with a dot are ignored
+* Support .gitignore file to ignore files and directories
 
 Also See `--help` for more options.
 

--- a/arg.go
+++ b/arg.go
@@ -31,6 +31,7 @@ type options struct {
 	noGroupSeparator bool
 	noIndent         bool
 	hidden           bool
+	skipGitIgnore    bool
 
 	contextLines uint32
 }
@@ -54,6 +55,7 @@ func (cli *runner) parseArgs() *options {
 	flag.BoolVarP(&o.noGroupSeparator, "no-group-separator", "", false, "When -C is in use, do not print a separator between groups of lines")
 	flag.BoolVarP(&o.noIndent, "no-indent", "", false, "Do not print an indent string")
 	flag.BoolVarP(&o.hidden, "hidden", "", false, "Search hidden files")
+	flag.BoolVarP(&o.skipGitIgnore, "skip-git-ignore", "", false, "Search files and directories if these match a line of .gitignore")
 	flag.Uint32VarP(&o.contextLines, "context", "C", 0, "Show several lines before and after the matched one")
 	flag.BoolVarP(&flagHelp, "help", "h", false, "Show help (This message) and exit")
 	flag.BoolVarP(&flagVersion, "version", "v", false, "Show version and build command info and exit")

--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,6 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	golang.org/x/sys v0.14.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -21,10 +21,12 @@ github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+e
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
 golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/bayashi/actually v0.23.0 h1:md0zWL5l/jcMieiAkH+7Qi6nW5iUtQfPqrr91S44e
 github.com/bayashi/actually v0.23.0/go.mod h1:uYS3+pX5HPH4f1YIiWiq4hkvjZMRApsGIb93sB19aIw=
 github.com/bayashi/witness v0.0.17 h1:f8bZL+MB+06DAF14YXgHqf7IF2oepcM2ILZ2H9khXOc=
 github.com/bayashi/witness v0.0.17/go.mod h1:xxXU08y35qzkp0kDRGVYuvHB5JVxFKe6vF16puu7gEo=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
@@ -15,9 +16,15 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
 golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main_test.go
+++ b/main_test.go
@@ -217,7 +217,7 @@ func TestRunner_OK(t *testing.T) {
 		},
 		"pick up ignorez dir with --skip-gitignore option": {
 			opt: &options{
-				searchPath: "service-f",
+				searchPath:    "service-f",
 				skipGitIgnore: true,
 			},
 			expect: here.Doc(`

--- a/main_test.go
+++ b/main_test.go
@@ -207,6 +207,14 @@ func TestRunner_OK(t *testing.T) {
                 testdata/service-e/.config
 			`),
 		},
+		"not pick up ignorez dir due to .gitignore": {
+			opt: &options{
+				searchPath: "service-f",
+			},
+			expect: here.Doc(`
+                testdata/service-f/
+			`),
+		},
 	} {
 		t.Run(tname, func(t *testing.T) {
 			var o bytes.Buffer

--- a/main_test.go
+++ b/main_test.go
@@ -215,6 +215,16 @@ func TestRunner_OK(t *testing.T) {
                 testdata/service-f/
 			`),
 		},
+		"pick up ignorez dir with --skip-gitignore option": {
+			opt: &options{
+				searchPath: "service-f",
+				skipGitIgnore: true,
+			},
+			expect: here.Doc(`
+                testdata/service-f/
+                testdata/service-f/ignorez/
+			`),
+		},
 	} {
 		t.Run(tname, func(t *testing.T) {
 			var o bytes.Buffer

--- a/testdata/.gitignore
+++ b/testdata/.gitignore
@@ -1,0 +1,1 @@
+ignorez

--- a/xfg.go
+++ b/xfg.go
@@ -108,12 +108,15 @@ func (x *xfg) Search() error {
 		return err
 	}
 
-	// read .gitignore file in start directory to search or home directory
-	// There would be no .gitignore file, then `gitignore` variable will be `nil`.
-	gitignore, _ := ignore.CompileIgnoreFile(filepath.Join(sPath, GIT_IGNOE_FILE_NAME))
-	if gitignore == nil {
-		if homeDir, err := os.UserHomeDir(); err == nil {
-			gitignore, _ = ignore.CompileIgnoreFile(filepath.Join(homeDir, GIT_IGNOE_FILE_NAME))
+	var gitignore *ignore.GitIgnore
+	if !x.options.skipGitIgnore {
+		// read .gitignore file in start directory to search or home directory
+		// There would be no .gitignore file, then `gitignore` variable will be `nil`.
+		gitignore, _ = ignore.CompileIgnoreFile(filepath.Join(sPath, GIT_IGNOE_FILE_NAME))
+		if gitignore == nil {
+			if homeDir, err := os.UserHomeDir(); err == nil {
+				gitignore, _ = ignore.CompileIgnoreFile(filepath.Join(homeDir, GIT_IGNOE_FILE_NAME))
+			}
 		}
 	}
 


### PR DESCRIPTION
* Read .gitignore file as locating current dir or `--start` directory
* Read ~/.gitignore file also if there is no .gitignore file within above location
* Use `--skip-gitignore` option to enable `.gitignore` file 