### PR TITLE
tiny fix: when output is non-TTY, then *contextLines should be defaul…

### DIFF
--- a/arg.go
+++ b/arg.go
@@ -137,7 +137,21 @@ func (o *options) targetPathFromArgs() {
 	}
 }
 
-func (o *options) prepareContextLines() {
+func (o *options) prepareContextLines(isTTY bool) {
+	if !isTTY {
+		o.contextLines = 0
+		o.afterContextLines = 0
+		o.beforeContextLines = 0
+
+		o.actualAfterContextLines = 0
+		o.actualBeforeContextLines = 0
+
+		o.withAfterContextLines = false
+		o.withBeforeContextLines = false
+
+		return
+	}
+
 	if o.afterContextLines > 0 {
 		o.actualAfterContextLines = o.afterContextLines
 	} else if o.contextLines > 0 {

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func (cli *runner) run() int {
 }
 
 func (cli *runner) xfg(o *options) (int, error) {
-	o.prepareContextLines()
+	o.prepareContextLines(cli.isTTY)
 	x := newX(o)
 
 	if err := x.search(); err != nil {

--- a/pager.go
+++ b/pager.go
@@ -21,7 +21,7 @@ const (
 )
 
 func (cli *runner) pager(noPager bool, result int) (func(), error) {
-	if noPager || !cli.isTTY {
+	if !cli.isTTY || noPager {
 		return nil, nil
 	}
 


### PR DESCRIPTION
…t value