### PR TITLE
remove --only-match option. Unnecessary for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ service-b/main.go
   -g, --grep stringArray         A string to search for contents
   -s, --start string             A location to start searching (default ".")
   -i, --ignore-case              Ignore case distinctions to search. Also affects keywords of ignore option
-  -o, --only-match               Show paths only matched contents
   -C, --context uint32           Show several lines before and after the matched one
   -A, --after-context uint32     Show several lines after the matched one. Override context option
   -B, --before-context uint32    Show several lines before the matched one. Override context option
@@ -102,6 +101,8 @@ service-b/main.go
   -c, --count                    Show a count of matching lines instead of contents
   -m, --max-count uint32         Stop reading a file after NUM matching lines
       --max-columns uint32       Do not print lines longer than this limit
+  -l, --files-with-matches       Only print the names of matching files
+  -0, --null                     Separate the filenames with \0, rather than \n
       --no-color                 Disable colors for an output
       --color-path string        Color name to highlight keywords in a path (default "cyan")
       --color-content string     Color name to highlight keywords in a content line (default "red")

--- a/arg.go
+++ b/arg.go
@@ -43,7 +43,6 @@ type options struct {
 	NoColor          bool `toml:"no-color"`
 	Abs              bool `toml:"abs"`
 	ShowMatchCount   bool `toml:"count"`
-	OnlyMatchContent bool `toml:"only-match"`
 	NoGroupSeparator bool `toml:"no-group-separator"`
 	NoIndent         bool `toml:"no-indent"`
 	Hidden           bool `toml:"hidden"`
@@ -68,6 +67,8 @@ type options struct {
 	actualBeforeContextLines uint32
 	withAfterContextLines    bool
 	withBeforeContextLines   bool
+
+	onlyMatchContent bool
 }
 
 func (cli *runner) parseArgs(d *options) *options {
@@ -83,7 +84,6 @@ func (cli *runner) parseArgs(d *options) *options {
 	flag.StringVarP(&o.SearchStart, "start", "s", d.SearchStart, "A location to start searching")
 
 	flag.BoolVarP(&o.IgnoreCase, "ignore-case", "i", d.IgnoreCase, "Ignore case distinctions to search. Also affects keywords of ignore option")
-	flag.BoolVarP(&o.OnlyMatchContent, "only-match", "o", d.OnlyMatchContent, "Show paths only matched contents")
 
 	flag.Uint32VarP(&o.ContextLines, "context", "C", d.ContextLines, "Show several lines before and after the matched one")
 	flag.Uint32VarP(&o.AfterContextLines, "after-context", "A", d.AfterContextLines, "Show several lines after the matched one. Override context option")
@@ -139,7 +139,7 @@ func (cli *runner) parseArgs(d *options) *options {
 	}
 
 	if len(o.SearchGrep) > 0 {
-		o.OnlyMatchContent = true
+		o.onlyMatchContent = true
 	}
 
 	return o

--- a/arg_test.go
+++ b/arg_test.go
@@ -97,7 +97,7 @@ func TestArgs(t *testing.T) {
 			args: []string{"--grep", "foo"},
 			prepareExpect: func(o *options) {
 				o.SearchGrep = []string{"foo"}
-				o.OnlyMatchContent = true
+				o.onlyMatchContent = true
 			},
 		},
 		"specific multiple paths": {
@@ -111,7 +111,7 @@ func TestArgs(t *testing.T) {
 			prepareExpect: func(o *options) {
 				o.SearchPath = []string{"foo"}
 				o.SearchGrep = []string{"bar"}
-				o.OnlyMatchContent = true
+				o.onlyMatchContent = true
 			},
 		},
 		"path and specific grep args": {
@@ -119,7 +119,7 @@ func TestArgs(t *testing.T) {
 			prepareExpect: func(o *options) {
 				o.SearchPath = []string{"foo"}
 				o.SearchGrep = []string{"bar"}
-				o.OnlyMatchContent = true
+				o.onlyMatchContent = true
 			},
 		},
 		"path and specific multiple greps": {
@@ -127,7 +127,7 @@ func TestArgs(t *testing.T) {
 			prepareExpect: func(o *options) {
 				o.SearchPath = []string{"foo"}
 				o.SearchGrep = []string{"bar", "baz"}
-				o.OnlyMatchContent = true
+				o.onlyMatchContent = true
 			},
 		},
 	} {

--- a/main_test.go
+++ b/main_test.go
@@ -68,7 +68,7 @@ func TestXfg_OK(t *testing.T) {
 			opt: &options{
 				SearchGrep:       []string{"package b"},
 				Indent:           defaultIndent,
-				OnlyMatchContent: true,
+				onlyMatchContent: true,
 			},
 			expect: here.Doc(`
                 testdata/service-b/main.go
@@ -151,7 +151,7 @@ func TestXfg_OK(t *testing.T) {
 				SearchPath:       []string{"service-a"},
 				SearchGrep:       []string{"foo"},
 				Indent:           defaultIndent,
-				OnlyMatchContent: true,
+				onlyMatchContent: true,
 			},
 			expect: here.Doc(`
                 testdata/service-a/main.go

--- a/test_util_test.go
+++ b/test_util_test.go
@@ -43,7 +43,7 @@ func expectedDefaultOptions() options {
 		NoColor:          false,
 		Abs:              false,
 		ShowMatchCount:   false,
-		OnlyMatchContent: false,
+		onlyMatchContent: false,
 		NoGroupSeparator: false,
 		NoIndent:         false,
 		Hidden:           false,

--- a/xfg.go
+++ b/xfg.go
@@ -213,7 +213,7 @@ func (x *xfg) canSkip(fPath string, fInfo fs.FileInfo) bool {
 		}
 	}
 
-	if fInfo.IsDir() && x.options.OnlyMatchContent {
+	if fInfo.IsDir() && x.options.onlyMatchContent {
 		return true // not pick up
 	}
 
@@ -250,7 +250,7 @@ func (x *xfg) onMatchPath(fPath string, fInfo fs.FileInfo) (err error) {
 		}
 	}
 
-	if x.options.OnlyMatchContent && len(matchedPath.contents) == 0 {
+	if x.options.onlyMatchContent && len(matchedPath.contents) == 0 {
 		return nil // not pick up
 	}
 


### PR DESCRIPTION
There still be in runtime option. It's automatically set.